### PR TITLE
feat(fase2): add shared PDF validator utility

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest==8.3.5
 pytest-asyncio==0.25.3
+pytest-cov==5.0.0
 httpx==0.28.1

--- a/backend/tests/test_pdf_validator.py
+++ b/backend/tests/test_pdf_validator.py
@@ -1,0 +1,208 @@
+"""Unit tests for shared PDF validator."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import HTTPException
+
+from utils.pdf_validator import validate_pdf_file, PDFInfo
+
+
+def _make_upload_file(filename="test.pdf", content_type="application/pdf"):
+    """Helper to create mock UploadFile."""
+    mock = MagicMock()
+    mock.filename = filename
+    mock.content_type = content_type
+    return mock
+
+
+class TestValidatePdfFile:
+    def test_empty_file_raises_400(self):
+        file = _make_upload_file()
+        with pytest.raises(HTTPException) as exc_info:
+            validate_pdf_file(file, b"")
+        assert exc_info.value.status_code == 400
+        assert "kosong" in exc_info.value.detail
+
+    def test_invalid_mime_type_raises_400(self):
+        file = _make_upload_file(content_type="text/plain")
+        with pytest.raises(HTTPException) as exc_info:
+            validate_pdf_file(file, b"%PDF-test")
+        assert exc_info.value.status_code == 400
+        assert "Tipe file" in exc_info.value.detail
+
+    def test_invalid_extension_raises_400(self):
+        file = _make_upload_file(filename="test.txt")
+        with pytest.raises(HTTPException) as exc_info:
+            validate_pdf_file(file, b"%PDF-test")
+        assert exc_info.value.status_code == 400
+        assert "Ekstensi" in exc_info.value.detail
+
+    def test_invalid_magic_bytes_raises_400(self):
+        file = _make_upload_file()
+        with pytest.raises(HTTPException) as exc_info:
+            validate_pdf_file(file, b"NOT-A-PDF-FILE")
+        assert exc_info.value.status_code == 400
+        assert "bukan file PDF" in exc_info.value.detail
+
+    def test_oversized_file_raises_413(self):
+        file = _make_upload_file()
+        big_bytes = b"%PDF" + b"x" * 2000
+        with pytest.raises(HTTPException) as exc_info:
+            validate_pdf_file(file, big_bytes, max_size_bytes=1024)
+        assert exc_info.value.status_code == 413
+        assert "terlalu besar" in exc_info.value.detail
+
+    def test_file_at_max_size_passes(self):
+        file = _make_upload_file()
+        # Exactly 1024 bytes with PDF magic
+        file_bytes = b"%PDF" + b"x" * 1020
+        with patch("utils.pdf_validator.fitz") as mock_fitz:
+            mock_doc = MagicMock()
+            mock_doc.page_count = 1
+            mock_doc.is_encrypted = False
+            mock_doc.close = MagicMock()
+            mock_fitz.open.return_value = mock_doc
+            with patch("utils.pdf_validator.settings") as mock_settings:
+                mock_settings.max_upload_size_bytes = 1024
+                result = validate_pdf_file(file, file_bytes)
+        assert isinstance(result, PDFInfo)
+        assert result.size_bytes == 1024
+
+    def test_custom_max_size_override(self):
+        file = _make_upload_file()
+        file_bytes = b"%PDF" + b"x" * 1500  # 1504 bytes total
+        # Default would be 20MB, but we override to 1024
+        with pytest.raises(HTTPException) as exc_info:
+            validate_pdf_file(file, file_bytes, max_size_bytes=1024)
+        assert exc_info.value.status_code == 413
+
+    def test_valid_pdf_returns_pdfinfo(self):
+        file = _make_upload_file()
+        # Minimal valid PDF bytes
+        file_bytes = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\nstartxref\n0\n%%EOF"
+        with patch("utils.pdf_validator.fitz") as mock_fitz:
+            mock_doc = MagicMock()
+            mock_doc.page_count = 1
+            mock_doc.is_encrypted = False
+            mock_doc.close = MagicMock()
+            mock_fitz.open.return_value = mock_doc
+            result = validate_pdf_file(file, file_bytes)
+        assert isinstance(result, PDFInfo)
+        assert result.size_bytes == len(file_bytes)
+        assert result.page_count == 1
+        assert result.is_encrypted is False
+        assert result.filename == "test.pdf"
+
+    def test_corrupted_pdf_raises_400(self):
+        file = _make_upload_file()
+        file_bytes = b"%PDF-corrupt"
+        with patch("utils.pdf_validator.fitz") as mock_fitz:
+            mock_fitz.open.side_effect = Exception("Corrupt PDF")
+            with pytest.raises(HTTPException) as exc_info:
+                validate_pdf_file(file, file_bytes)
+        assert exc_info.value.status_code == 400
+        assert "corrupt" in exc_info.value.detail
+
+    def test_page_count_exceeds_limit_raises_400(self):
+        file = _make_upload_file()
+        file_bytes = b"%PDF-test"
+        with patch("utils.pdf_validator.fitz") as mock_fitz:
+            mock_doc = MagicMock()
+            mock_doc.page_count = 10
+            mock_doc.is_encrypted = False
+            mock_doc.close = MagicMock()
+            mock_fitz.open.return_value = mock_doc
+            with pytest.raises(HTTPException) as exc_info:
+                validate_pdf_file(file, file_bytes, max_pages=5)
+        assert exc_info.value.status_code == 400
+        assert "terlalu panjang" in exc_info.value.detail
+
+    def test_page_count_within_limit_passes(self):
+        file = _make_upload_file()
+        file_bytes = b"%PDF-test"
+        with patch("utils.pdf_validator.fitz") as mock_fitz:
+            mock_doc = MagicMock()
+            mock_doc.page_count = 3
+            mock_doc.is_encrypted = False
+            mock_doc.close = MagicMock()
+            mock_fitz.open.return_value = mock_doc
+            result = validate_pdf_file(file, file_bytes, max_pages=5)
+        assert result.page_count == 3
+
+    def test_reject_encrypted_true_raises_400(self):
+        file = _make_upload_file()
+        file_bytes = b"%PDF-test"
+        with patch("utils.pdf_validator.fitz") as mock_fitz:
+            mock_doc = MagicMock()
+            mock_doc.page_count = 1
+            mock_doc.is_encrypted = True
+            mock_doc.close = MagicMock()
+            mock_fitz.open.return_value = mock_doc
+            with pytest.raises(HTTPException) as exc_info:
+                validate_pdf_file(file, file_bytes, reject_encrypted=True)
+        assert exc_info.value.status_code == 400
+        assert "dilindungi kata sandi" in exc_info.value.detail
+
+    def test_require_encrypted_true_raises_400(self):
+        file = _make_upload_file()
+        file_bytes = b"%PDF-test"
+        with patch("utils.pdf_validator.fitz") as mock_fitz:
+            mock_doc = MagicMock()
+            mock_doc.page_count = 1
+            mock_doc.is_encrypted = False
+            mock_doc.close = MagicMock()
+            mock_fitz.open.return_value = mock_doc
+            with pytest.raises(HTTPException) as exc_info:
+                validate_pdf_file(file, file_bytes, require_encrypted=True)
+        assert exc_info.value.status_code == 400
+        assert "tidak terproteksi" in exc_info.value.detail
+
+    def test_encrypted_status_detected_correctly(self):
+        file = _make_upload_file()
+        file_bytes = b"%PDF-test"
+        with patch("utils.pdf_validator.fitz") as mock_fitz:
+            mock_doc = MagicMock()
+            mock_doc.page_count = 1
+            mock_doc.is_encrypted = True
+            mock_doc.close = MagicMock()
+            mock_fitz.open.return_value = mock_doc
+            result = validate_pdf_file(file, file_bytes)
+        assert result.is_encrypted is True
+
+    def test_filename_none_defaults_to_unknown(self):
+        file = _make_upload_file(filename="test.pdf")
+        file_bytes = b"%PDF-test"
+        with patch("utils.pdf_validator.fitz") as mock_fitz:
+            mock_doc = MagicMock()
+            mock_doc.page_count = 1
+            mock_doc.is_encrypted = False
+            mock_doc.close = MagicMock()
+            mock_fitz.open.return_value = mock_doc
+            result = validate_pdf_file(file, file_bytes)
+        assert result.filename == "test.pdf"
+
+    def test_extension_case_insensitive(self):
+        file = _make_upload_file(filename="test.PDF")
+        file_bytes = b"%PDF-test"
+        with patch("utils.pdf_validator.fitz") as mock_fitz:
+            mock_doc = MagicMock()
+            mock_doc.page_count = 1
+            mock_doc.is_encrypted = False
+            mock_doc.close = MagicMock()
+            mock_fitz.open.return_value = mock_doc
+            result = validate_pdf_file(file, file_bytes)
+        assert isinstance(result, PDFInfo)
+
+
+class TestPDFInfo:
+    def test_pdfinfo_dataclass(self):
+        info = PDFInfo(
+            size_bytes=1024,
+            page_count=5,
+            is_encrypted=False,
+            filename="test.pdf"
+        )
+        assert info.size_bytes == 1024
+        assert info.page_count == 5
+        assert info.is_encrypted is False
+        assert info.filename == "test.pdf"

--- a/backend/utils/pdf_validator.py
+++ b/backend/utils/pdf_validator.py
@@ -1,0 +1,142 @@
+"""
+Shared PDF validation utilities for Papyr.
+
+Digunakan oleh semua endpoint yang menerima file PDF.
+Validasi: kosong, MIME type, ekstensi, magic bytes, ukuran, page count, encrypted status.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import fitz  # PyMuPDF
+from fastapi import UploadFile, HTTPException
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+# Constants
+ALLOWED_MIME_TYPES = {"application/pdf"}
+ALLOWED_EXTENSIONS = {".pdf"}
+PDF_MAGIC = b"%PDF"
+
+
+@dataclass
+class PDFInfo:
+    """Metadata hasil validasi PDF."""
+
+    size_bytes: int
+    page_count: int
+    is_encrypted: bool
+    filename: str
+
+
+def validate_pdf_file(
+    file: UploadFile,
+    file_bytes: bytes,
+    *,
+    max_size_bytes: Optional[int] = None,
+    max_pages: Optional[int] = None,
+    require_encrypted: bool = False,
+    reject_encrypted: bool = False,
+) -> PDFInfo:
+    """
+    Validasi file PDF secara komprehensif.
+
+    Args:
+        file: FastAPI UploadFile object.
+        file_bytes: Raw bytes dari file.
+        max_size_bytes: Override max size (default: settings.max_upload_size_bytes).
+        max_pages: Jika set, tolak PDF dengan halaman lebih dari ini.
+        require_encrypted: Jika True, tolak PDF yang TIDAK terenkripsi.
+        reject_encrypted: Jika True, tolak PDF yang terenkripsi.
+
+    Returns:
+        PDFInfo dengan metadata file.
+
+    Raises:
+        HTTPException: Jika validasi gagal.
+    """
+    filename = file.filename or "unknown"
+    size_bytes = len(file_bytes)
+    effective_max = max_size_bytes or settings.max_upload_size_bytes
+
+    # 1. File tidak kosong
+    if size_bytes == 0:
+        raise HTTPException(
+            status_code=400,
+            detail="File kosong. Silakan upload file PDF yang valid.",
+        )
+
+    # 2. MIME type
+    if file.content_type not in ALLOWED_MIME_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Tipe file tidak valid: {file.content_type}. Hanya file PDF yang diterima.",
+        )
+
+    # 3. Ekstensi
+    ext = ""
+    if "." in filename:
+        ext = "." + filename.rsplit(".", 1)[-1].lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Ekstensi file tidak valid: '{ext}'. Hanya file .pdf yang diterima.",
+        )
+
+    # 4. Magic bytes
+    if file_bytes[:4] != PDF_MAGIC:
+        raise HTTPException(
+            status_code=400,
+            detail=f'"{filename}" bukan file PDF yang valid. Konten file tidak sesuai format PDF.',
+        )
+
+    # 5. Ukuran
+    if size_bytes > effective_max:
+        max_mb = effective_max / (1024 * 1024)
+        actual_mb = round(size_bytes / (1024 * 1024), 1)
+        raise HTTPException(
+            status_code=413,
+            detail=f"Ukuran file terlalu besar: {actual_mb}MB. Maksimal {max_mb:.0f}MB.",
+        )
+
+    # 6. Buka PDF untuk metadata
+    try:
+        doc = fitz.open(stream=file_bytes, filetype="pdf")
+        page_count = doc.page_count
+        is_encrypted = doc.is_encrypted
+        doc.close()
+    except Exception:
+        raise HTTPException(
+            status_code=400,
+            detail=f'"{filename}" bukan file PDF yang valid atau file corrupt.',
+        )
+
+    # 7. Page count limit
+    if max_pages and page_count > max_pages:
+        raise HTTPException(
+            status_code=400,
+            detail=f"PDF terlalu panjang: {page_count} halaman. Maksimal {max_pages} halaman.",
+        )
+
+    # 8. Encrypted status checks
+    if reject_encrypted and is_encrypted:
+        raise HTTPException(
+            status_code=400,
+            detail="PDF ini dilindungi kata sandi. Gunakan fitur Unlock terlebih dahulu.",
+        )
+
+    if require_encrypted and not is_encrypted:
+        raise HTTPException(
+            status_code=400,
+            detail="PDF ini tidak terproteksi. Fitur ini hanya untuk PDF yang dilindungi password.",
+        )
+
+    return PDFInfo(
+        size_bytes=size_bytes,
+        page_count=page_count,
+        is_encrypted=is_encrypted,
+        filename=filename,
+    )

--- a/stepprompts/progress.md
+++ b/stepprompts/progress.md
@@ -3,9 +3,9 @@
 > **Instruksi:** Setelah menyelesaikan setiap STEP, update status di file ini menjadi ✅ beserta tanggal selesai.
 > Format: `| STEP-F2-XXX | Judul | ⬜ |` → `| STEP-F2-XXX | Judul | ✅ YYYY-MM-DD |`
 
-**Last Updated:** —
-**Current Step:** STEP-F2-001
-**Overall Progress:** 0 / 97 (0%)
+**Last Updated:** 2026-05-14
+**Current Step:** STEP-F2-002
+**Overall Progress:** 1 / 97 (1%)
 
 ---
 
@@ -13,13 +13,13 @@
 
 | Fase | Steps | Done | Progress |
 |------|-------|------|----------|
-| 2A — Security (M12+M13) | 13 | 0 | 0% |
+| 2A — Security (M12+M13) | 13 | 1 | 8% |
 | 2B — Enhancement (M14+M15) | 16 | 0 | 0% |
 | 2C — Conversion (M16+M17+M18) | 11 | 0 | 0% |
 | 2D — Quality (M19+M20) | 14 | 0 | 0% |
 | 2E — OpenClaw (M21) | 28 | 0 | 0% |
 | 2F — Dashboard (M22) | 15 | 0 | 0% |
-| **TOTAL** | **97** | **0** | **0%** |
+| **TOTAL** | **97** | **1** | **1%** |
 
 ---
 
@@ -29,7 +29,7 @@
 
 | Step | Title | Status |
 |------|-------|--------|
-| STEP-F2-001 | Backend — Create shared PDF validator utility | ⬜ |
+| STEP-F2-001 | Backend — Create shared PDF validator utility | ✅ 2026-05-14 |
 | STEP-F2-002 | Backend — Create encryption service (shared protect/unlock) | ⬜ |
 | STEP-F2-003 | Backend — Create POST /api/protect endpoint | ⬜ |
 | STEP-F2-004 | Backend — Unit tests for protect endpoint | ⬜ |


### PR DESCRIPTION
## Summary
- Add shared `validate_pdf_file()` utility and `PDFInfo` dataclass for Fase 2 endpoints.
- Add comprehensive unit tests for validator logic with edge-case coverage.
- Update Fase 2 progress tracker to mark STEP-F2-001 complete.

## Verification
- `python -m pytest tests/test_pdf_validator.py -v --cov=utils.pdf_validator --cov-report=term-missing --cov-fail-under=90`
- Result: 17 passed, module coverage 100%.