### PR TITLE
feat(fase2): add encryption service (encrypt + decrypt PDF)

### DIFF
--- a/backend/services/encryption.py
+++ b/backend/services/encryption.py
@@ -1,0 +1,227 @@
+"""
+PDF encryption/decryption service using PyMuPDF (fitz).
+
+Shared antara:
+- POST /api/protect (encrypt)
+- POST /api/unlock (decrypt)
+
+Supports AES-128 and AES-256 encryption methods.
+"""
+
+import logging
+import os
+import tempfile
+
+import fitz  # PyMuPDF
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+# Encryption method mapping
+PDF_ENCRYPT_AES_128 = getattr(fitz, "PDF_ENCRYPT_AES_128")
+PDF_ENCRYPT_AES_256 = getattr(fitz, "PDF_ENCRYPT_AES_256")
+PDF_PERM_ACCESSIBILITY = getattr(fitz, "PDF_PERM_ACCESSIBILITY")
+PDF_PERM_ANNOTATE = getattr(fitz, "PDF_PERM_ANNOTATE")
+PDF_PERM_FORM = getattr(fitz, "PDF_PERM_FORM")
+
+ENCRYPTION_METHODS = {
+    "aes128": PDF_ENCRYPT_AES_128,
+    "aes256": PDF_ENCRYPT_AES_256,
+}
+
+# Permission flags — deny print and copy by default
+DEFAULT_PERMISSIONS = (
+    PDF_PERM_ACCESSIBILITY
+    | PDF_PERM_ANNOTATE
+    | PDF_PERM_FORM
+)
+
+
+def encrypt_pdf(
+    file_bytes: bytes,
+    password: str,
+    method: str = "aes256",
+    permissions: int | None = None,
+) -> bytes:
+    """
+    Enkripsi PDF dengan password menggunakan PyMuPDF.
+
+    Args:
+        file_bytes: Raw PDF bytes.
+        password: Password untuk enkripsi (user_pw dan owner_pw sama).
+        method: "aes128" atau "aes256".
+        permissions: Permission flags (default: deny print + copy).
+
+    Returns:
+        Encrypted PDF bytes.
+
+    Raises:
+        HTTPException(400): Jika metode enkripsi tidak valid atau file corrupt.
+        HTTPException(409): Jika PDF sudah terenkripsi.
+        HTTPException(500): Jika enkripsi gagal.
+    """
+    encryption_flag = ENCRYPTION_METHODS.get(method)
+    if encryption_flag is None:
+        logger.warning("Metode enkripsi tidak valid: '%s'", method)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Metode enkripsi tidak valid: '{method}'. Pilihan: aes128, aes256.",
+        )
+
+    if not password:
+        raise HTTPException(
+            status_code=400,
+            detail="Password tidak boleh kosong.",
+        )
+
+    perm = permissions if permissions is not None else DEFAULT_PERMISSIONS
+
+    doc = None
+    output_path = None
+    try:
+        doc = fitz.open(stream=file_bytes, filetype="pdf")
+    except Exception:
+        raise HTTPException(
+            status_code=400,
+            detail="File PDF tidak bisa dibuka. File mungkin corrupt.",
+        )
+
+    try:
+        if doc.is_encrypted:
+            logger.warning("PDF sudah terenkripsi")
+            raise HTTPException(
+                status_code=409,
+                detail="PDF sudah terenkripsi. Tidak bisa menambahkan proteksi ganda.",
+            )
+
+        fd, output_path = tempfile.mkstemp(suffix=".pdf", prefix="papyr_enc_")
+        os.close(fd)
+
+        doc.save(
+            output_path,
+            encryption=encryption_flag,
+            owner_pw=password,
+            user_pw=password,
+            permissions=perm,
+        )
+
+        with open(output_path, "rb") as f:
+            encrypted_bytes = f.read()
+
+        if not encrypted_bytes:
+            raise HTTPException(
+                status_code=500,
+                detail="Enkripsi gagal — output file kosong.",
+            )
+
+        logger.info(
+            "PDF encrypted: method=%s input_size=%d output_size=%d",
+            method, len(file_bytes), len(encrypted_bytes),
+        )
+
+        return encrypted_bytes
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Encryption failed: %s", str(exc))
+        raise HTTPException(
+            status_code=500,
+            detail="Gagal mengenkripsi PDF. Silakan coba lagi.",
+        )
+    finally:
+        _cleanup(output_path)
+        if doc is not None:
+            doc.close()
+
+
+def decrypt_pdf(file_bytes: bytes, password: str) -> bytes:
+    """
+    Dekripsi PDF dengan password menggunakan PyMuPDF.
+
+    Args:
+        file_bytes: Raw encrypted PDF bytes.
+        password: Password untuk mendekripsi.
+
+    Returns:
+        Decrypted PDF bytes (tanpa proteksi).
+
+    Raises:
+        HTTPException(400): Jika file tidak terenkripsi atau corrupt.
+        HTTPException(401): Jika password salah.
+        HTTPException(500): Jika dekripsi gagal.
+    """
+    if not password:
+        raise HTTPException(
+            status_code=400,
+            detail="Password tidak boleh kosong.",
+        )
+
+    doc = None
+    output_path = None
+    try:
+        doc = fitz.open(stream=file_bytes, filetype="pdf")
+    except Exception:
+        raise HTTPException(
+            status_code=400,
+            detail="File PDF tidak bisa dibuka. File mungkin corrupt.",
+        )
+
+    try:
+        if not doc.is_encrypted:
+            logger.warning("PDF tidak terenkripsi")
+            raise HTTPException(
+                status_code=400,
+                detail="PDF ini tidak terproteksi.",
+            )
+
+        auth_result = doc.authenticate(password)
+        if auth_result == 0:
+            logger.warning("Password salah untuk PDF terenkripsi")
+            raise HTTPException(
+                status_code=401,
+                detail="Password salah.",
+            )
+
+        fd, output_path = tempfile.mkstemp(suffix=".pdf", prefix="papyr_dec_")
+        os.close(fd)
+
+        doc.save(output_path, encryption=0)
+
+        with open(output_path, "rb") as f:
+            decrypted_bytes = f.read()
+
+        if not decrypted_bytes:
+            raise HTTPException(
+                status_code=500,
+                detail="Dekripsi gagal — output file kosong.",
+            )
+
+        logger.info(
+            "PDF decrypted: input_size=%d output_size=%d",
+            len(file_bytes), len(decrypted_bytes),
+        )
+
+        return decrypted_bytes
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Decryption failed: %s", str(exc))
+        raise HTTPException(
+            status_code=500,
+            detail="Gagal mendekripsi PDF. Silakan coba lagi.",
+        )
+    finally:
+        _cleanup(output_path)
+        if doc is not None:
+            doc.close()
+
+
+def _cleanup(path: str | None) -> None:
+    """Hapus file jika ada, abaikan error."""
+    try:
+        if path and os.path.exists(path):
+            os.remove(path)
+    except OSError:
+        pass

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -1,0 +1,278 @@
+"""Unit tests for shared encryption service."""
+
+import importlib
+
+import pytest
+import fitz
+from unittest.mock import MagicMock, mock_open as mock_file_open, patch
+from fastapi import HTTPException
+
+encryption = importlib.import_module("services.encryption")
+encrypt_pdf = encryption.encrypt_pdf
+decrypt_pdf = encryption.decrypt_pdf
+_cleanup = encryption._cleanup
+ENCRYPTION_METHODS = encryption.ENCRYPTION_METHODS
+DEFAULT_PERMISSIONS = encryption.DEFAULT_PERMISSIONS
+PDF_ENCRYPT_AES_128 = encryption.PDF_ENCRYPT_AES_128
+PDF_ENCRYPT_AES_256 = encryption.PDF_ENCRYPT_AES_256
+PDF_PERM_ACCESSIBILITY = encryption.PDF_PERM_ACCESSIBILITY
+PDF_PERM_ANNOTATE = encryption.PDF_PERM_ANNOTATE
+PDF_PERM_FORM = encryption.PDF_PERM_FORM
+
+
+def _make_minimal_pdf_bytes() -> bytes:
+    """Create a minimal valid PDF in memory using fitz."""
+    doc = MagicMock()
+    doc.page_count = 1
+    doc.is_encrypted = False
+    doc.close = MagicMock()
+    return b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\nstartxref\n0\n%%EOF"
+
+
+def _make_mock_doc(is_encrypted: bool = False, authenticate_result: int = 2):
+    """Create a mock fitz.Document."""
+    mock_doc = MagicMock()
+    mock_doc.is_encrypted = is_encrypted
+    mock_doc.authenticate.return_value = authenticate_result
+    mock_doc.close = MagicMock()
+    return mock_doc
+
+
+class TestEncryptPdf:
+    def test_invalid_method_raises_400(self):
+        file_bytes = b"%PDF-test"
+        with pytest.raises(HTTPException) as exc_info:
+            encrypt_pdf(file_bytes, "password123", method="aes512")
+        assert exc_info.value.status_code == 400
+        assert "aes128" in exc_info.value.detail or "aes256" in exc_info.value.detail
+
+    def test_empty_password_raises_400(self):
+        file_bytes = b"%PDF-test"
+        with pytest.raises(HTTPException) as exc_info:
+            encrypt_pdf(file_bytes, "")
+        assert exc_info.value.status_code == 400
+        assert "kosong" in exc_info.value.detail.lower() or "tidak boleh" in exc_info.value.detail
+
+    def test_corrupt_pdf_raises_400(self):
+        file_bytes = b"NOT_A_PDF"
+        with pytest.raises(HTTPException) as exc_info:
+            encrypt_pdf(file_bytes, "password123")
+        assert exc_info.value.status_code == 400
+        assert "corrupt" in exc_info.value.detail or "tidak bisa dibuka" in exc_info.value.detail
+
+    def test_already_encrypted_raises_409(self):
+        file_bytes = b"%PDF-test"
+        with patch("services.encryption.fitz.open") as mock_open:
+            mock_open.return_value = _make_mock_doc(is_encrypted=True)
+            with pytest.raises(HTTPException) as exc_info:
+                encrypt_pdf(file_bytes, "password123")
+            assert exc_info.value.status_code == 409
+            assert "sudah terenkripsi" in exc_info.value.detail or "proteksi ganda" in exc_info.value.detail
+
+    def test_aes256_encrypt_success(self):
+        file_bytes = _make_minimal_pdf_bytes()
+        with patch("services.encryption.fitz.open") as mock_open, \
+             patch("services.encryption.tempfile.mkstemp") as mock_mkstemp, \
+             patch("services.encryption.os.close") as mock_close, \
+             patch("services.encryption.os.path.exists", return_value=True), \
+             patch("services.encryption.os.remove") as mock_remove, \
+             patch("builtins.open", mock_file_open(read_data=b"encrypted_pdf_content")):
+
+            mock_mkstemp.return_value = (99, "/tmp/papyr_enc_xxx.pdf")
+            mock_doc = _make_mock_doc(is_encrypted=False)
+            mock_open.return_value = mock_doc
+
+            result = encrypt_pdf(file_bytes, "password123", method="aes256")
+
+            assert result == b"encrypted_pdf_content"
+            mock_doc.save.assert_called_once()
+            call_kwargs = mock_doc.save.call_args.kwargs
+            assert call_kwargs["encryption"] == ENCRYPTION_METHODS["aes256"]
+            assert call_kwargs["owner_pw"] == "password123"
+            assert call_kwargs["user_pw"] == "password123"
+
+    def test_aes128_encrypt_success(self):
+        file_bytes = _make_minimal_pdf_bytes()
+        with patch("services.encryption.fitz.open") as mock_open, \
+             patch("services.encryption.tempfile.mkstemp") as mock_mkstemp, \
+             patch("services.encryption.os.close") as mock_close, \
+             patch("services.encryption.os.path.exists", return_value=True), \
+             patch("services.encryption.os.remove") as mock_remove, \
+             patch("builtins.open", mock_file_open(read_data=b"encrypted_pdf_content")):
+
+            mock_mkstemp.return_value = (99, "/tmp/papyr_enc_xxx.pdf")
+            mock_doc = _make_mock_doc(is_encrypted=False)
+            mock_open.return_value = mock_doc
+
+            result = encrypt_pdf(file_bytes, "password123", method="aes128")
+
+            assert result == b"encrypted_pdf_content"
+            call_kwargs = mock_doc.save.call_args.kwargs
+            assert call_kwargs["encryption"] == ENCRYPTION_METHODS["aes128"]
+
+    def test_custom_permissions(self):
+        file_bytes = _make_minimal_pdf_bytes()
+        custom_perms = PDF_PERM_ANNOTATE | PDF_PERM_ACCESSIBILITY
+        with patch("services.encryption.fitz.open") as mock_open, \
+             patch("services.encryption.tempfile.mkstemp") as mock_mkstemp, \
+             patch("services.encryption.os.close") as mock_close, \
+             patch("services.encryption.os.path.exists", return_value=True), \
+             patch("services.encryption.os.remove") as mock_remove, \
+             patch("builtins.open", mock_file_open(read_data=b"encrypted")):
+
+            mock_mkstemp.return_value = (99, "/tmp/papyr_enc_xxx.pdf")
+            mock_doc = _make_mock_doc(is_encrypted=False)
+            mock_open.return_value = mock_doc
+
+            encrypt_pdf(file_bytes, "password123", method="aes256", permissions=custom_perms)
+
+            call_kwargs = mock_doc.save.call_args.kwargs
+            assert call_kwargs["permissions"] == custom_perms
+
+    def test_output_empty_raises_500(self):
+        file_bytes = _make_minimal_pdf_bytes()
+        with patch("services.encryption.fitz.open") as mock_open, \
+             patch("services.encryption.tempfile.mkstemp") as mock_mkstemp, \
+             patch("services.encryption.os.close") as mock_close, \
+             patch("services.encryption.os.path.exists", return_value=True), \
+             patch("services.encryption.os.remove") as mock_remove, \
+             patch("builtins.open", mock_file_open(read_data=b"")):
+
+            mock_mkstemp.return_value = (99, "/tmp/papyr_enc_xxx.pdf")
+            mock_doc = _make_mock_doc(is_encrypted=False)
+            mock_open.return_value = mock_doc
+
+            with pytest.raises(HTTPException) as exc_info:
+                encrypt_pdf(file_bytes, "password123", method="aes256")
+            assert exc_info.value.status_code == 500
+            assert "kosong" in exc_info.value.detail or "gagal" in exc_info.value.detail.lower()
+
+    def test_unexpected_error_raises_500(self):
+        file_bytes = _make_minimal_pdf_bytes()
+        with patch("services.encryption.fitz.open") as mock_open, \
+             patch("services.encryption.tempfile.mkstemp") as mock_mkstemp, \
+             patch("services.encryption.os.close"):
+            mock_mkstemp.return_value = (99, "/tmp/papyr_enc_xxx.pdf")
+            mock_doc = _make_mock_doc(is_encrypted=False)
+            mock_doc.save.side_effect = RuntimeError("Unexpected error")
+            mock_open.return_value = mock_doc
+
+            with pytest.raises(HTTPException) as exc_info:
+                encrypt_pdf(file_bytes, "password123", method="aes256")
+            assert exc_info.value.status_code == 500
+
+
+class TestDecryptPdf:
+    def test_empty_password_raises_400(self):
+        file_bytes = b"%PDF-test"
+        with pytest.raises(HTTPException) as exc_info:
+            decrypt_pdf(file_bytes, "")
+        assert exc_info.value.status_code == 400
+        assert "kosong" in exc_info.value.detail.lower() or "tidak boleh" in exc_info.value.detail
+
+    def test_corrupt_pdf_raises_400(self):
+        file_bytes = b"NOT_A_PDF"
+        with pytest.raises(HTTPException) as exc_info:
+            decrypt_pdf(file_bytes, "password123")
+        assert exc_info.value.status_code == 400
+        assert "corrupt" in exc_info.value.detail or "tidak bisa dibuka" in exc_info.value.detail
+
+    def test_not_encrypted_raises_400(self):
+        file_bytes = b"%PDF-test"
+        with patch("services.encryption.fitz.open") as mock_open:
+            mock_open.return_value = _make_mock_doc(is_encrypted=False)
+            with pytest.raises(HTTPException) as exc_info:
+                decrypt_pdf(file_bytes, "password123")
+            assert exc_info.value.status_code == 400
+            assert "tidak terproteksi" in exc_info.value.detail or "terenkripsi" in exc_info.value.detail.lower()
+
+    def test_wrong_password_raises_401(self):
+        file_bytes = b"%PDF-test"
+        with patch("services.encryption.fitz.open") as mock_open:
+            mock_doc = _make_mock_doc(is_encrypted=True, authenticate_result=0)
+            mock_open.return_value = mock_doc
+            with pytest.raises(HTTPException) as exc_info:
+                decrypt_pdf(file_bytes, "wrongpassword")
+            assert exc_info.value.status_code == 401
+            assert "salah" in exc_info.value.detail.lower()
+
+    def test_correct_password_decrypts_success(self):
+        file_bytes = b"%PDF-encrypted"
+        with patch("services.encryption.fitz.open") as mock_open, \
+             patch("services.encryption.tempfile.mkstemp") as mock_mkstemp, \
+             patch("services.encryption.os.close") as mock_close, \
+             patch("services.encryption.os.path.exists", return_value=True), \
+             patch("services.encryption.os.remove") as mock_remove, \
+             patch("builtins.open", mock_file_open(read_data=b"decrypted_pdf_content")):
+
+            mock_mkstemp.return_value = (99, "/tmp/papyr_dec_xxx.pdf")
+            mock_doc = _make_mock_doc(is_encrypted=True, authenticate_result=2)
+            mock_open.return_value = mock_doc
+
+            result = decrypt_pdf(file_bytes, "correctpassword")
+
+            assert result == b"decrypted_pdf_content"
+            mock_doc.authenticate.assert_called_once_with("correctpassword")
+            mock_doc.save.assert_called_once_with("/tmp/papyr_dec_xxx.pdf", encryption=0)
+
+    def test_output_empty_raises_500(self):
+        file_bytes = b"%PDF-encrypted"
+        with patch("services.encryption.fitz.open") as mock_open, \
+             patch("services.encryption.tempfile.mkstemp") as mock_mkstemp, \
+             patch("services.encryption.os.close") as mock_close, \
+             patch("services.encryption.os.path.exists", return_value=True), \
+             patch("services.encryption.os.remove") as mock_remove, \
+             patch("builtins.open", mock_file_open(read_data=b"")):
+
+            mock_mkstemp.return_value = (99, "/tmp/papyr_dec_xxx.pdf")
+            mock_doc = _make_mock_doc(is_encrypted=True, authenticate_result=2)
+            mock_open.return_value = mock_doc
+
+            with pytest.raises(HTTPException) as exc_info:
+                decrypt_pdf(file_bytes, "correctpassword")
+            assert exc_info.value.status_code == 500
+
+    def test_unexpected_error_raises_500(self):
+        file_bytes = b"%PDF-test"
+        with patch("services.encryption.fitz.open") as mock_open, \
+             patch("services.encryption.tempfile.mkstemp") as mock_mkstemp, \
+             patch("services.encryption.os.close"):
+            mock_mkstemp.return_value = (99, "/tmp/papyr_dec_xxx.pdf")
+            mock_doc = _make_mock_doc(is_encrypted=True, authenticate_result=2)
+            mock_doc.save.side_effect = RuntimeError("Unexpected error")
+            mock_open.return_value = mock_doc
+
+            with pytest.raises(HTTPException) as exc_info:
+                decrypt_pdf(file_bytes, "password123")
+            assert exc_info.value.status_code == 500
+
+
+class TestCleanup:
+    def test_cleanup_removes_existing_file(self):
+        with patch("services.encryption.os.path.exists", return_value=True), \
+             patch("services.encryption.os.remove") as mock_remove:
+            _cleanup("/tmp/test_file.pdf")
+            mock_remove.assert_called_once_with("/tmp/test_file.pdf")
+
+    def test_cleanup_nonexistent_path_noop(self):
+        with patch("services.encryption.os.path.exists", return_value=False), \
+             patch("services.encryption.os.remove") as mock_remove:
+            _cleanup("/tmp/nonexistent.pdf")
+            mock_remove.assert_not_called()
+
+    def test_cleanup_oserror_noop(self):
+        with patch("services.encryption.os.path.exists", return_value=True), \
+             patch("services.encryption.os.remove", side_effect=OSError):
+            # Should not raise
+            _cleanup("/tmp/test_file.pdf")
+
+
+class TestConstants:
+    def test_encryption_methods_contains_aes128_aes256(self):
+        assert "aes128" in ENCRYPTION_METHODS
+        assert "aes256" in ENCRYPTION_METHODS
+        assert ENCRYPTION_METHODS["aes128"] == PDF_ENCRYPT_AES_128
+        assert ENCRYPTION_METHODS["aes256"] == PDF_ENCRYPT_AES_256
+
+    def test_default_permissions_is_nonzero(self):
+        assert DEFAULT_PERMISSIONS != 0

--- a/stepprompts/progress.md
+++ b/stepprompts/progress.md
@@ -4,8 +4,8 @@
 > Format: `| STEP-F2-XXX | Judul | ⬜ |` → `| STEP-F2-XXX | Judul | ✅ YYYY-MM-DD |`
 
 **Last Updated:** 2026-05-14
-**Current Step:** STEP-F2-002
-**Overall Progress:** 1 / 97 (1%)
+**Current Step:** STEP-F2-003
+**Overall Progress:** 2 / 97 (2%)
 
 ---
 
@@ -13,13 +13,13 @@
 
 | Fase | Steps | Done | Progress |
 |------|-------|------|----------|
-| 2A — Security (M12+M13) | 13 | 1 | 8% |
+| 2A — Security (M12+M13) | 13 | 2 | 15% |
 | 2B — Enhancement (M14+M15) | 16 | 0 | 0% |
 | 2C — Conversion (M16+M17+M18) | 11 | 0 | 0% |
 | 2D — Quality (M19+M20) | 14 | 0 | 0% |
 | 2E — OpenClaw (M21) | 28 | 0 | 0% |
 | 2F — Dashboard (M22) | 15 | 0 | 0% |
-| **TOTAL** | **97** | **1** | **1%** |
+| **TOTAL** | **97** | **2** | **2%** |
 
 ---
 
@@ -30,7 +30,7 @@
 | Step | Title | Status |
 |------|-------|--------|
 | STEP-F2-001 | Backend — Create shared PDF validator utility | ✅ 2026-05-14 |
-| STEP-F2-002 | Backend — Create encryption service (shared protect/unlock) | ⬜ |
+| STEP-F2-002 | Backend — Create encryption service (shared protect/unlock) | ✅ 2026-05-14 |
 | STEP-F2-003 | Backend — Create POST /api/protect endpoint | ⬜ |
 | STEP-F2-004 | Backend — Unit tests for protect endpoint | ⬜ |
 | STEP-F2-005 | Frontend — Create /protect page with full UI | ⬜ |


### PR DESCRIPTION
## Summary
- Add shared `services.encryption` with AES-128/AES-256 PDF encryption and decrypt support.
- Add unit tests for success paths, wrong passwords, already-encrypted PDFs, cleanup, permissions, and failure handling.
- Mark STEP-F2-002 complete in the Fase 2 progress tracker.

## Verification
- `python -m pytest tests/test_encryption.py -q --cov=services.encryption --cov-report=term-missing --cov-fail-under=90`
- Result: 21 passed, `services/encryption.py` coverage 100%.
- `python -c "from services.encryption import encrypt_pdf, decrypt_pdf; print('OK')"`
- LSP diagnostics: no errors for `backend/services/encryption.py` and `backend/tests/test_encryption.py`.

## Deploy note
- Backend deploy should trigger after merge because Railway tracks `main`.
- Frontend deploy remains deferred until Phase 2A completion, per instruction.
