### PR TITLE
feat(fase2): add POST /api/protect endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from routers.connectivity import router as connectivity_router
 from routers.compress import router as compress_router
 from routers.image_to_pdf import router as image_to_pdf_router
 from routers.pdf_to_image import router as pdf_to_image_router
+from routers.protect import router as protect_router
 from utils.config import settings
 from utils.logging_config import setup_logging
 from utils.cleanup import cleanup_expired_files, CLEANUP_INTERVAL_SECONDS
@@ -94,6 +95,7 @@ app.include_router(connectivity_router)
 app.include_router(compress_router)
 app.include_router(image_to_pdf_router)
 app.include_router(pdf_to_image_router)
+app.include_router(protect_router)
 
 
 @app.get("/health")

--- a/backend/routers/protect.py
+++ b/backend/routers/protect.py
@@ -1,0 +1,147 @@
+"""
+Router untuk proteksi PDF (password protect).
+
+POST /api/protect — menerima file PDF + password, validasi, enkripsi via PyMuPDF,
+upload ke R2, dan return signed download URL.
+"""
+
+import logging
+import time
+from datetime import datetime, timezone, timedelta
+
+from fastapi import APIRouter, File, Form, Request, UploadFile, HTTPException
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from utils.config import settings
+from utils.logging_config import log_task_event
+from utils.pdf_validator import validate_pdf_file
+from services.encryption import encrypt_pdf, ENCRYPTION_METHODS
+from utils.r2 import upload_file, generate_signed_url
+
+limiter = Limiter(key_func=get_remote_address)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api", tags=["protect"])
+
+# Password constraints
+_PASSWORD_MIN_LENGTH = 4
+_PASSWORD_MAX_LENGTH = 128
+
+
+@router.post("/protect")
+@limiter.limit(f"{settings.rate_limit_per_minute}/minute")
+async def protect_endpoint(
+    request: Request,
+    file: UploadFile = File(...),
+    password: str = Form(...),
+    encryption: str = Form("aes256"),
+):
+    """
+    Proteksi file PDF dengan password menggunakan AES encryption.
+
+    - **file**: File PDF (multipart/form-data)
+    - **password**: Password untuk proteksi (4-128 karakter)
+    - **encryption**: Metode enkripsi — `aes128` atau `aes256` (default: aes256)
+
+    Returns:
+        success, download_url, expires_at, original_size, output_size
+    """
+    # 1. Baca file dan start timing BEFORE try
+    file_bytes = await file.read()
+    start_time = time.time()
+    input_size = len(file_bytes)
+
+    try:
+        # 2. Validasi PDF (shared validator — reject encrypted)
+        pdf_info = validate_pdf_file(file, file_bytes, reject_encrypted=True)
+
+        # 3. Validasi password length
+        if len(password) < _PASSWORD_MIN_LENGTH:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Password terlalu pendek. Minimal {_PASSWORD_MIN_LENGTH} karakter.",
+            )
+        if len(password) > _PASSWORD_MAX_LENGTH:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Password terlalu panjang. Maksimal {_PASSWORD_MAX_LENGTH} karakter.",
+            )
+
+        # 4. Validasi encryption method
+        if encryption not in ENCRYPTION_METHODS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Metode enkripsi tidak valid: '{encryption}'. Pilihan: aes128, aes256.",
+            )
+
+        # 5. Enkripsi PDF
+        encrypted_bytes = encrypt_pdf(file_bytes, password, method=encryption)
+
+        # 6. Upload ke R2
+        original_filename = file.filename or "protected.pdf"
+        r2_result = upload_file(
+            file_bytes=encrypted_bytes,
+            original_filename=original_filename,
+            content_type="application/pdf",
+        )
+
+        # 7. Generate signed URL (1 jam)
+        dl_name = f"protected_{file.filename}" if file.filename else "protected.pdf"
+        download_url = generate_signed_url(
+            r2_result["key"], expiry_seconds=3600, download_filename=dl_name
+        )
+
+        # 8. Response
+        duration_ms = int((time.time() - start_time) * 1000)
+        log_task_event(
+            logger,
+            event="task_completed",
+            tool="protect",
+            duration_ms=duration_ms,
+            input_size_bytes=input_size,
+            success=True,
+            encryption_method=encryption,
+        )
+
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=3600)
+        ).isoformat()
+
+        return {
+            "success": True,
+            "download_url": download_url,
+            "expires_at": expires_at,
+            "original_size": pdf_info.size_bytes,
+            "output_size": len(encrypted_bytes),
+        }
+
+    except HTTPException:
+        duration_ms = int((time.time() - start_time) * 1000)
+        log_task_event(
+            logger,
+            event="task_failed",
+            tool="protect",
+            duration_ms=duration_ms,
+            input_size_bytes=input_size,
+            success=False,
+            error="validation_error",
+        )
+        raise
+
+    except Exception as exc:
+        duration_ms = int((time.time() - start_time) * 1000)
+        log_task_event(
+            logger,
+            event="task_failed",
+            tool="protect",
+            duration_ms=duration_ms,
+            input_size_bytes=input_size,
+            success=False,
+            error=type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Gagal memproteksi file. Silakan coba lagi.",
+        )

--- a/backend/tests/test_protect.py
+++ b/backend/tests/test_protect.py
@@ -1,0 +1,397 @@
+"""Unit tests for POST /api/protect endpoint.
+
+Covers: happy path, validation errors, encryption edge cases.
+Refs: PAPYR-092, PAPYR-093
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import HTTPException
+
+# Minimal PDF-like bytes for tests
+VALID_PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\nstartxref\n0\n%%EOF"
+
+
+def _build_file(name: str, data: bytes, content_type: str):
+    """Build files dict for multipart upload."""
+    return {"file": (name, data, content_type)}
+
+
+def _mock_pdf_info(size: int = 1024, page_count: int = 1, is_encrypted: bool = False):
+    """Create a mock PDFInfo from the validator."""
+    mock = MagicMock()
+    mock.size_bytes = size
+    mock.page_count = page_count
+    mock.is_encrypted = is_encrypted
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_protect_aes256_success(test_client):
+    """Happy path — AES-256 encryption, all mocked."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.encrypt_pdf") as mock_encrypt,
+        patch("routers.protect.upload_file") as mock_upload,
+        patch("routers.protect.generate_signed_url") as mock_url,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info(size=1024)
+        mock_encrypt.return_value = b"encrypted_pdf_bytes"
+        mock_upload.return_value = {"key": "r2/protected_test.pdf"}
+        mock_url.return_value = "https://signed.url/protected_test.pdf"
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "securepass123", "encryption": "aes256"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert "download_url" in body
+        assert "expires_at" in body
+        assert body["original_size"] == 1024
+        assert body["output_size"] == len(b"encrypted_pdf_bytes")
+
+        # Verify encrypt_pdf was called with correct method
+        mock_encrypt.assert_called_once()
+        _, kwargs = mock_encrypt.call_args
+        assert kwargs["method"] == "aes256"
+
+        # Verify validate_pdf_file was called with reject_encrypted=True
+        mock_validate.assert_called_once()
+        _, kwargs = mock_validate.call_args
+        assert kwargs["reject_encrypted"] is True
+
+
+@pytest.mark.asyncio
+async def test_protect_aes128_success(test_client):
+    """Happy path — AES-128 encryption."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.encrypt_pdf") as mock_encrypt,
+        patch("routers.protect.upload_file") as mock_upload,
+        patch("routers.protect.generate_signed_url") as mock_url,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info(size=2048)
+        mock_encrypt.return_value = b"encrypted_aes128"
+        mock_upload.return_value = {"key": "r2/protected.pdf"}
+        mock_url.return_value = "https://signed.url/protected.pdf"
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "test1234", "encryption": "aes128"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        mock_encrypt.assert_called_once()
+        _, kwargs = mock_encrypt.call_args
+        assert kwargs["method"] == "aes128"
+
+
+@pytest.mark.asyncio
+async def test_protect_empty_file_returns_400(test_client):
+    """Empty file should be rejected by validator."""
+    response = await test_client.post(
+        "/api/protect",
+        files=_build_file("empty.pdf", b"", "application/pdf"),
+        data={"password": "test1234"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_protect_invalid_mime_type_returns_400(test_client):
+    """Non-PDF MIME type rejected."""
+    response = await test_client.post(
+        "/api/protect",
+        files=_build_file("test.txt", VALID_PDF_BYTES, "text/plain"),
+        data={"password": "test1234"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_protect_invalid_extension_returns_400(test_client):
+    """Wrong file extension rejected."""
+    response = await test_client.post(
+        "/api/protect",
+        files=_build_file("test.docx", VALID_PDF_BYTES, "application/pdf"),
+        data={"password": "test1234"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_protect_corrupt_pdf_returns_400(test_client):
+    """Corrupt PDF file rejected."""
+    corrupt_bytes = b"NOT_A_PDF_AT_ALL"
+    with patch("routers.protect.validate_pdf_file") as mock_validate:
+        mock_validate.side_effect = HTTPException(
+            status_code=400, detail="File PDF tidak bisa dibuka. File mungkin corrupt."
+        )
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("corrupt.pdf", corrupt_bytes, "application/pdf"),
+            data={"password": "test1234"},
+        )
+        assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_protect_already_encrypted_returns_409(test_client):
+    """Already-encrypted PDF rejected with 409."""
+    with patch("routers.protect.validate_pdf_file") as mock_validate:
+        mock_validate.side_effect = HTTPException(
+            status_code=409, detail="PDF sudah terenkripsi."
+        )
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("locked.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "test1234"},
+        )
+        assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_protect_password_too_short_returns_400(test_client):
+    """Password less than 4 characters rejected."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info()
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "abc", "encryption": "aes256"},
+        )
+        assert response.status_code == 400
+        assert "terlalu pendek" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_protect_password_too_long_returns_400(test_client):
+    """Password more than 128 characters rejected."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info()
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "a" * 129, "encryption": "aes256"},
+        )
+        assert response.status_code == 400
+        assert "terlalu panjang" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_protect_invalid_encryption_method_returns_400(test_client):
+    """Unsupported encryption method rejected."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info()
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "test1234", "encryption": "aes512"},
+        )
+        assert response.status_code == 400
+        assert "tidak valid" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_protect_rc4_method_rejected(test_client):
+    """RC4 (unsupported) method rejected."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info()
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "test1234", "encryption": "rc4"},
+        )
+        assert response.status_code == 400
+        assert "aes128" in response.json()["detail"] or "tidak valid" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_protect_missing_password_returns_422(test_client):
+    """Missing password field returns 422."""
+    response = await test_client.post(
+        "/api/protect",
+        files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+        data={},
+    )
+    # FastAPI validation: missing required Form field → 422
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_protect_missing_file_returns_422(test_client):
+    """Missing file field returns 422."""
+    response = await test_client.post(
+        "/api/protect",
+        data={"password": "test1234"},
+    )
+    # FastAPI validation: missing required File field → 422
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_protect_encryption_failure_returns_500(test_client):
+    """When encrypt_pdf raises unexpected error, returns 500."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.encrypt_pdf") as mock_encrypt,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info()
+        mock_encrypt.side_effect = RuntimeError("Encryption failed")
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "test1234", "encryption": "aes256"},
+        )
+        assert response.status_code == 500
+        assert "Gagal memproteksi" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_protect_upload_failure_returns_500(test_client):
+    """When R2 upload fails, returns 500."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.encrypt_pdf") as mock_encrypt,
+        patch("routers.protect.upload_file") as mock_upload,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info()
+        mock_encrypt.return_value = b"encrypted"
+        mock_upload.side_effect = RuntimeError("R2 unavailable")
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "test1234", "encryption": "aes256"},
+        )
+        assert response.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_protect_expires_at_is_iso_string(test_client):
+    """Response expires_at should be an ISO datetime string."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.encrypt_pdf") as mock_encrypt,
+        patch("routers.protect.upload_file") as mock_upload,
+        patch("routers.protect.generate_signed_url") as mock_url,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info()
+        mock_encrypt.return_value = b"encrypted"
+        mock_upload.return_value = {"key": "r2/key.pdf"}
+        mock_url.return_value = "https://url"
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "test1234", "encryption": "aes256"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        # expires_at should be ISO format: "2026-05-14T..."
+        assert "T" in body["expires_at"]
+        assert "Z" in body["expires_at"] or "+" in body["expires_at"]
+
+
+@pytest.mark.asyncio
+async def test_protect_original_size_from_pdf_info(test_client):
+    """original_size should come from pdf_info.size_bytes, not raw input size."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.encrypt_pdf") as mock_encrypt,
+        patch("routers.protect.upload_file") as mock_upload,
+        patch("routers.protect.generate_signed_url") as mock_url,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info(size=9999)
+        mock_encrypt.return_value = b"encrypted"
+        mock_upload.return_value = {"key": "r2/key.pdf"}
+        mock_url.return_value = "https://url"
+
+        # Upload bytes are different from pdf_info.size_bytes
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "test1234", "encryption": "aes256"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["original_size"] == 9999  # from pdf_info, not len(VALID_PDF_BYTES)
+
+
+@pytest.mark.asyncio
+async def test_protect_password_exactly_4_chars_accepted(test_client):
+    """Password of exactly 4 characters should be accepted."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.encrypt_pdf") as mock_encrypt,
+        patch("routers.protect.upload_file") as mock_upload,
+        patch("routers.protect.generate_signed_url") as mock_url,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info()
+        mock_encrypt.return_value = b"encrypted"
+        mock_upload.return_value = {"key": "r2/key.pdf"}
+        mock_url.return_value = "https://url"
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "test", "encryption": "aes256"},
+        )
+        assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_protect_password_128_chars_accepted(test_client):
+    """Password of exactly 128 characters should be accepted."""
+    with (
+        patch("routers.protect.validate_pdf_file") as mock_validate,
+        patch("routers.protect.encrypt_pdf") as mock_encrypt,
+        patch("routers.protect.upload_file") as mock_upload,
+        patch("routers.protect.generate_signed_url") as mock_url,
+        patch("routers.protect.log_task_event"),
+    ):
+        mock_validate.return_value = _mock_pdf_info()
+        mock_encrypt.return_value = b"encrypted"
+        mock_upload.return_value = {"key": "r2/key.pdf"}
+        mock_url.return_value = "https://url"
+
+        response = await test_client.post(
+            "/api/protect",
+            files=_build_file("test.pdf", VALID_PDF_BYTES, "application/pdf"),
+            data={"password": "a" * 128, "encryption": "aes256"},
+        )
+        assert response.status_code == 200

--- a/stepprompts/progress.md
+++ b/stepprompts/progress.md
@@ -4,8 +4,8 @@
 > Format: `| STEP-F2-XXX | Judul | ⬜ |` → `| STEP-F2-XXX | Judul | ✅ YYYY-MM-DD |`
 
 **Last Updated:** 2026-05-14
-**Current Step:** STEP-F2-003
-**Overall Progress:** 2 / 97 (2%)
+**Current Step:** STEP-F2-004
+**Overall Progress:** 3 / 97 (3%)
 
 ---
 
@@ -13,13 +13,13 @@
 
 | Fase | Steps | Done | Progress |
 |------|-------|------|----------|
-| 2A — Security (M12+M13) | 13 | 2 | 15% |
+| 2A — Security (M12+M13) | 13 | 3 | 23% |
 | 2B — Enhancement (M14+M15) | 16 | 0 | 0% |
 | 2C — Conversion (M16+M17+M18) | 11 | 0 | 0% |
 | 2D — Quality (M19+M20) | 14 | 0 | 0% |
 | 2E — OpenClaw (M21) | 28 | 0 | 0% |
 | 2F — Dashboard (M22) | 15 | 0 | 0% |
-| **TOTAL** | **97** | **2** | **2%** |
+| **TOTAL** | **97** | **3** | **3%** |
 
 ---
 
@@ -31,7 +31,7 @@
 |------|-------|--------|
 | STEP-F2-001 | Backend — Create shared PDF validator utility | ✅ 2026-05-14 |
 | STEP-F2-002 | Backend — Create encryption service (shared protect/unlock) | ✅ 2026-05-14 |
-| STEP-F2-003 | Backend — Create POST /api/protect endpoint | ⬜ |
+| STEP-F2-003 | Backend — Create POST /api/protect endpoint | ✅ 2026-05-14 |
 | STEP-F2-004 | Backend — Unit tests for protect endpoint | ⬜ |
 | STEP-F2-005 | Frontend — Create /protect page with full UI | ⬜ |
 | STEP-F2-006 | Frontend — Create PasswordInput shared component | ⬜ |


### PR DESCRIPTION
## Summary
- Add `POST /api/protect` router with shared PDF validation + encryption flow.
- Register protect router in `backend/main.py`.
- Add comprehensive endpoint tests for protect flow and edge cases.
- Update Fase 2 progress tracker to mark STEP-F2-003 complete.

## Verification Evidence
- `python -m pytest tests/test_protect.py -v --cov=routers.protect --cov-report=term-missing --cov-fail-under=90`
- Result: 19 passed, 100% coverage on `routers/protect.py`.
- Import check: `python -c "from routers.protect import router; print('OK')"` → `OK`.
